### PR TITLE
Accessibility Suggestion

### DIFF
--- a/static/css/base/login.css
+++ b/static/css/base/login.css
@@ -25,7 +25,7 @@
     box-sizing: border-box;
     border-radius: 4px;
     border: 2px solid #0000001a;
-    outline: none;
+    outline-color: transparent;
     background: #7575752c;
 }
 .form__input:focus{
@@ -39,7 +39,7 @@
     color: #ffffff;
     border: none;
     border-radius: 4px;
-    outline: none;
+    outline-color: transparent;
     cursor: pointer;
     background: #2d3436;
 }


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8